### PR TITLE
chore: update SDK dep version to v0.1.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/loft-sh/vcluster-sync-all-configmaps
 go 1.17
 
 require (
-	github.com/loft-sh/vcluster-sdk v0.1.0
+	github.com/loft-sh/vcluster-sdk v0.1.1
 	k8s.io/api v0.23.1
 	k8s.io/apimachinery v0.23.1
 	sigs.k8s.io/controller-runtime v0.11.0

--- a/go.sum
+++ b/go.sum
@@ -266,8 +266,6 @@ github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
-github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -372,10 +370,8 @@ github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0/go.mod h1:YBCo4D
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhnIaL+V+BEER86oLrvS+kWobKpbJuye0=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
-github.com/loft-sh/vcluster-sdk v0.0.0-20220118172507-6dc71f7a315f h1:DKjmpfku5k6V4WnKGIBMUmX61kzLmzeb0vvnzbsxcX0=
-github.com/loft-sh/vcluster-sdk v0.0.0-20220118172507-6dc71f7a315f/go.mod h1:Y3ow5o8Iue2g5cO0BIcdxQxBYs/Pv9cSH89wxcXFZ+M=
-github.com/loft-sh/vcluster-sdk v0.1.0 h1:bgD4dbHXXPgjz5/r2l1gvZTbti4XG9P8gW3QlM3wbGg=
-github.com/loft-sh/vcluster-sdk v0.1.0/go.mod h1:Y3ow5o8Iue2g5cO0BIcdxQxBYs/Pv9cSH89wxcXFZ+M=
+github.com/loft-sh/vcluster-sdk v0.1.1 h1:FhSIjyL+J5lb7mZhKISteQQ+rQbvJJ8rxyeTJktVAf8=
+github.com/loft-sh/vcluster-sdk v0.1.1/go.mod h1:Y3ow5o8Iue2g5cO0BIcdxQxBYs/Pv9cSH89wxcXFZ+M=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=

--- a/vendor/github.com/loft-sh/vcluster-sdk/syncer/context/context.go
+++ b/vendor/github.com/loft-sh/vcluster-sdk/syncer/context/context.go
@@ -80,9 +80,9 @@ type RegisterContext struct {
 	SyncerConfig clientcmd.ClientConfig
 }
 
-// VirtualClusterOptions holds the vcluster flags that were used to start the vcluster
+// VirtualClusterOptions holds the cmd flags
 type VirtualClusterOptions struct {
-	Controllers string `json:"controllers,omitempty"`
+	Controllers []string `json:"controllers,omitempty"`
 
 	ServerCaCert        string   `json:"serverCaCert,omitempty"`
 	ServerCaKey         string   `json:"serverCaKey,omitempty"`
@@ -91,9 +91,10 @@ type VirtualClusterOptions struct {
 	ClientCaCert        string   `json:"clientCaCert"`
 	KubeConfig          string   `json:"kubeConfig"`
 
-	KubeConfigSecret          string `json:"kubeConfigSecret"`
-	KubeConfigSecretNamespace string `json:"kubeConfigSecretNamespace"`
-	KubeConfigServer          string `json:"kubeConfigServer"`
+	KubeConfigSecret          string   `json:"kubeConfigSecret"`
+	KubeConfigSecretNamespace string   `json:"kubeConfigSecretNamespace"`
+	KubeConfigServer          string   `json:"kubeConfigServer"`
+	Tolerations               []string `json:"tolerations,omitempty"`
 
 	BindAddress string `json:"bindAddress"`
 	Port        int    `json:"port"`
@@ -127,6 +128,12 @@ type VirtualClusterOptions struct {
 
 	DisablePlugins      bool   `json:"disablePlugins"`
 	PluginListenAddress string `json:"pluginListenAddress"`
+
+	DefaultImageRegistry string `json:"defaultImageRegistry"`
+
+	EnforcePodSecurityStandard string `json:"enforcePodSecurityStandard"`
+
+	SyncLabels []string `json:"syncLabels"`
 
 	// DEPRECATED FLAGS
 	DeprecatedDisableSyncResources     string

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -114,7 +114,7 @@ github.com/json-iterator/go
 # github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
 ## explicit
 github.com/liggitt/tabwriter
-# github.com/loft-sh/vcluster-sdk v0.1.0
+# github.com/loft-sh/vcluster-sdk v0.1.1
 ## explicit; go 1.17
 github.com/loft-sh/vcluster-sdk/applier
 github.com/loft-sh/vcluster-sdk/clienthelper


### PR DESCRIPTION
Updating `github.com/loft-sh/vcluster-sdk` dependency to v0.1.1 to pick up a bug fix.